### PR TITLE
Make template not appear as if it's linking issues

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,8 +1,8 @@
-<!-- 
+<!--
 Thanks for opening a pull request and helping improve Enarx.
 
 Please remember to:
-- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #123" or "Resolves enarx/repo-name#123", cf.
+- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
   [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
 - ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
 - lastly, ensure there are no merge commits!


### PR DESCRIPTION
This caused a bug in the Enarxbot -- it thought the closing keywords in the template boilerplate was valid. While the real fix is likely deeper, this should at least work around the problem.
