### PR TITLE
feat: recommend enarx platform info in the bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -39,7 +39,7 @@ body:
   - type: textarea
     attributes:
       label: Environment Information
-      description: "Please paste output of following command: `uname -a; enarx --version; enarx info`"
+      description: "Please paste output of following command: `uname -a; enarx --version; enarx platform info`"
     validations:
       required: true
   - type: markdown


### PR DESCRIPTION
We recently changed from using `enarx info` to `enarx platform info` so we might want to use the newer one (or both :shrug:)