### PR TITLE
Update link to contribution guide

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -4,7 +4,7 @@ Thanks for opening a pull request and helping improve Enarx.
 Please remember to:
 - mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
   [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
+- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
 - lastly, ensure there are no merge commits!
 Thank you :)
 -->


### PR DESCRIPTION
The DCO link in the PR template links to a wiki page that redirects to another page - remove one level of indirection.

Signed-off-by: Andreas Stührk <andy@yaxi.tech>
